### PR TITLE
Check if recv data exceeds buffer size

### DIFF
--- a/turbo-genesis-sdk/src/canvas/macros.rs
+++ b/turbo-genesis-sdk/src/canvas/macros.rs
@@ -268,6 +268,7 @@ macro_rules! __text__ {
     (@set $text:ident, xy, $val:expr) => { $text.position_xy($val) };
     (@set $text:ident, position, $val:expr) => { $text.position_xy($val) };
     (@set $text:ident, rotation, $val:expr) => { $text.rotation_deg($val) };
+    (@set $text:ident, scale, $val:expr) => { $text.scale($val) };
     (@set $text:ident, $key:ident, $val:expr) => { $text.$key($val) };
 }
 

--- a/turbo-genesis-sdk/src/canvas/text.rs
+++ b/turbo-genesis-sdk/src/canvas/text.rs
@@ -301,11 +301,14 @@ impl<'a> Text<'a> {
         }
 
         // Set the fixed positioning flag
-        let flags = if self.quad.fixed {
+        let mut flags = if self.quad.fixed {
             flags::POSITION_FIXED
         } else {
             0
         };
+
+        // Set the sprite cover flag
+        flags |= flags::SPRITE_COVER;
 
         // Apply opacity to the sprite's primary and background colors.
         let color = utils::color::apply_opacity(self.quad.color, self.quad.opacity);

--- a/turbo-genesis-sdk/src/os/client/channel.rs
+++ b/turbo-genesis-sdk/src/os/client/channel.rs
@@ -152,6 +152,10 @@ impl<Tx: BorshSerialize, Rx: BorshDeserialize> ChannelConnection<Tx, Rx> {
             &mut err_len,
         );
 
+        if data_len as usize > data.len() {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, format!("Received data_len {} exceeds buffer size {}", data_len, data.len())));
+        }
+
         match status {
             STATUS_OK => Rx::try_from_slice(&data[..data_len as usize]),
             STATUS_EMPTY => Err(io::Error::new(


### PR DESCRIPTION
My game was crashing because I was spawning too many projectiles, and I was able to catch the error with this change.